### PR TITLE
define vendor key for added metadata

### DIFF
--- a/design.org
+++ b/design.org
@@ -1,4 +1,6 @@
 # Copyright (C) 2018 Jan Malakhovski
+# Copyright (C) 2018 Lance R. Vick
+
 # Permission is granted to copy, distribute and/or modify this document
 # under the terms of the GNU Free Documentation License, Version 1.3
 # or any later version published by the Free Software Foundation;
@@ -163,6 +165,12 @@ of other reviewers
 - "+" = "I approve".
 
 "priority": self-explanatory.
+# Copyright (C) 2018 Leo Gaspard
+
+Tools that desire to add additional metadata MUST place it under the'vendor'
+key which is reserved for this purpouse. Tools SHOULD use a subkey under
+'vendor' key named the same as the tool. The default verification command in a
+tool MUST NOT interpret data under the 'vendor' key.
 
 ** Examples
 


### PR DESCRIPTION
So I feel we need an added statement to add a compromise for #10

I know many orgs will have extra metadata they want to sign as part of automation or general evidence etc. Maybe an org wants to include their CI job ID, or has their own review format. Maybe they already use something like Google's git-appraise and want to be able to include hashes of their detailed review blobs from the refs/notes/devtools/reviews ref in their git/refs/signatures. Maybe they want to include ticket numbers from their internal issue system etc.

I don't think we should stop people from including data they feel is valuable to show context around a change, but we should regulate that it goes somewhere that the spec won't ever interpret.

I suggest we include a vendor key to allow for use cases we can't think of yet.

E.g. make new pre-spec git-signatures features use the: ""vendor: { git-signatures:{} }" namespace